### PR TITLE
Add Modular Map documentation system

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -129,6 +129,24 @@ Do NOT test: rendering, input, anything needing a live scene.
 
 ---
 
+## Documentation & Context Maintenance
+
+### The Map Protocol
+- **Always** read `/docs/map_directories/map.md` first when starting a new session or before working on any system you are unfamiliar with.
+- `map.md` is the high-level index of all game systems. Use it to navigate to the relevant system bucket file before reading source code.
+- Each system bucket file in `/docs/map_directories/` is the authoritative prose description of that system's purpose, dependencies, signals, and public API.
+
+### Automatic Updates
+After implementing any significant logic change or new system, Claude must update the relevant `.md` file(s) in `/docs/map_directories/` to reflect:
+- Changed or new signals
+- Changed or new public methods
+- New dependencies on other systems
+- Structural or design decisions made during implementation
+
+If a change affects multiple systems (e.g., a new signal crosses two systems), update **both** bucket files and the index in `map.md` if a new system was added.
+
+---
+
 ## Open Questions / Deferred
 
 - Grid size: 6×4 — may adjust after playtest

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,0 +1,36 @@
+# RogueFinder — Backlog
+
+> Ordered by priority within each stage. Items move to "Done" when merged to main.
+
+---
+
+## Stage 1.5 — 3D Combat Prototype (Current)
+
+### Immediate
+- [ ] Open project in Godot, assign UIDs, run first playtest
+- [ ] Document playtest failures → create bug tickets below
+
+### Known Deferred
+- [ ] Grid size tuning (currently 6×4 — may adjust post-playtest)
+- [ ] Balance numbers (HP, ATK, DEF placeholders — TBD after playtest)
+- [ ] QTE variety (sliding bar only — more types TBD for Stage 2)
+
+---
+
+## Stage 2 — Scope TBD
+
+> Design gate: complete Stage 1.5 playtest first.
+
+Candidates (from GAME_BIBLE):
+- [ ] Node map / traversal system
+- [ ] Recruitment system
+- [ ] Enemy variety (elite tier, unique abilities)
+- [ ] GameState wired to combat outcomes
+- [ ] Persistent party across encounters
+
+---
+
+## Done
+
+- [x] Stage 1 — 2D combat prototype (6×4 grid, click-to-move, 3v3, QTE, HUD, tests)
+- [x] Stage 1.5 — 3D refactor (CameraController, Unit3D, Grid3D, CombatManager3D)

--- a/docs/map_directories/camera_system.md
+++ b/docs/map_directories/camera_system.md
@@ -1,0 +1,108 @@
+# System: Camera System
+
+> Last updated: 2026-04-14 (Session 2 — Stage 1.5)
+
+---
+
+## Purpose
+
+The Camera System provides a **DOS2-style isometric orbit camera** for the 3D combat scene. It handles:
+- Fixed-elevation orbit around a target point
+- Q/E key rotation in 45° snapped steps
+- Mouse scroll wheel zoom
+- Procedural camera shake on combat events (hit feedback)
+
+The camera is built and owned by `CombatManager3D`. No `.tscn` — it's instantiated entirely in code.
+
+---
+
+## Core Nodes / Scripts
+
+| File | Scene | Role |
+|------|-------|------|
+| `scripts/camera/CameraController.gd` | *(none — built in code)* | Orbit camera + shake |
+
+---
+
+## Dependencies
+
+None. CameraController is a self-contained `Node3D` that builds its own `Camera3D` child. It has no knowledge of other game systems.
+
+CombatManager3D calls `trigger_shake()` on it; Unit3D optionally calls `get_sprite_dir()` passing the camera's forward vector.
+
+---
+
+## Signals Emitted
+
+None.
+
+---
+
+## Public Methods
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `trigger_shake` | `() -> void` | Starts a 0.22s procedural shake (called by CombatManager on hit) |
+| `get_forward` | `() -> Vector3` | Returns the camera's forward direction (for 8-dir sprite selection) |
+| `get_camera` | `() -> Camera3D` | Returns the child Camera3D node (used by Grid3D for raycasting) |
+
+---
+
+## Camera Parameters
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `DEFAULT_DISTANCE` | 16.0 | Default orbit radius |
+| `MIN_DISTANCE` | 8.0 | Minimum zoom distance |
+| `MAX_DISTANCE` | 28.0 | Maximum zoom distance |
+| `DEFAULT_ELEVATION` | 52.0° | Fixed camera pitch (isometric-style) |
+| `DEFAULT_YAW` | 225.0° | Starting yaw angle |
+| `ROTATE_STEP` | 45.0° | Q/E rotation increment |
+| `ZOOM_STEP` | 2.0 | Scroll wheel zoom increment |
+| `SHAKE_DURATION` | 0.22 s | Duration of shake effect |
+| `SHAKE_MAGNITUDE` | 0.18 | Max displacement per shake tick |
+
+---
+
+## Input Handling
+
+| Input | Action |
+|-------|--------|
+| `Q` | Rotate orbit left by 45° |
+| `E` | Rotate orbit right by 45° |
+| `ScrollUp` | Zoom in (decrease distance) |
+| `ScrollDown` | Zoom out (increase distance) |
+
+Panning is not yet implemented — the camera always looks at the grid origin (0, 0, 0).
+
+---
+
+## Shake Implementation
+
+`trigger_shake()` sets `_shake_timer = SHAKE_DURATION`. Each `_process()` tick while `_shake_timer > 0`:
+1. Generates a random offset within `SHAKE_MAGNITUDE` on X and Y.
+2. Applies the offset to the Camera3D's local position.
+3. Decrements `_shake_timer` by `delta`.
+4. Clears the offset when the timer expires.
+
+Shake is additive on top of the normal orbit transform, computed in `_apply_transform()`.
+
+---
+
+## Transform Pipeline (`_apply_transform`)
+
+```
+1. Build rotation from yaw (Y-axis) and elevation (X-axis).
+2. Compute camera offset: rotation * Vector3(0, 0, distance).
+3. Set controller position to target + offset.
+4. Point controller at target using look_at().
+5. Add shake offset to Camera3D local position.
+```
+
+---
+
+## Notes
+
+- The Camera3D child is created in `_ready()` — calling `get_camera()` before `_ready()` returns null.
+- `DEFAULT_ELEVATION` of 52° matches a near-isometric look without a true 45° projection, which gives a more readable 3D battlefield.
+- Rotation steps snap to 45° multiples — there is no smooth rotation tween in Stage 1.5; may be added later.

--- a/docs/map_directories/combat_manager.md
+++ b/docs/map_directories/combat_manager.md
@@ -1,0 +1,120 @@
+# System: Combat Manager
+
+> Last updated: 2026-04-14 (Session 2 — Stage 1.5)
+
+---
+
+## Purpose
+
+The Combat Manager is the **root authority** for a combat encounter. It owns the entire scene — building the environment, camera, grid, units, and UI entirely in `_ready()`. It runs the turn state machine, routes all player input, executes enemy AI, triggers the QTE flow, calculates damage, and decides win/lose conditions.
+
+There are two versions: `CombatManager3D.gd` (active, 3D) and `CombatManager.gd` (legacy 2D, kept for reference).
+
+---
+
+## Core Nodes / Scripts
+
+| File | Scene | Role |
+|------|-------|------|
+| `scripts/combat/CombatManager3D.gd` | `scenes/combat/CombatScene3D.tscn` | **Active** — 3D state machine |
+| `scripts/combat/CombatManager.gd` | `scenes/combat/CombatScene.tscn` | Legacy 2D — reference only |
+
+`CombatScene3D.tscn` is the active entry point. `main.tscn` loads it.
+
+---
+
+## Dependencies
+
+| System | How it's used |
+|--------|--------------|
+| **Grid3D** | Cell queries (`is_valid`, `is_occupied`, `get_unit_at`), move range, highlights, world↔grid math |
+| **Unit3D** | HP/energy reads, `take_damage()`, `move_to()`, `play_attack_anim()`, `reset_turn()`, signal subscriptions |
+| **QTEBar** | `start_qte()` call; listens for `qte_resolved(accuracy)` signal |
+| **HUD** | `refresh(player_units, enemy_units)` called after every state change |
+| **CameraController** | Built by CM3D; `trigger_shake()` called on successful hit |
+| **UnitData** | Constructed by `_make_unit_data()` and passed into `Unit3D.setup()` |
+
+---
+
+## State Machine
+
+```
+PLAYER_TURN
+  └─[player selects unit + action]─→ QTE_RUNNING (on attack)
+                                   └─→ PLAYER_TURN (after stride or if all acted)
+QTE_RUNNING
+  └─[qte_resolved signal]─→ ENEMY_TURN (if all player units acted)
+                          └─→ PLAYER_TURN (if others remain)
+ENEMY_TURN
+  └─[all enemies processed]─→ PLAYER_TURN
+                            └─→ WIN / LOSE
+
+WIN  → prints "YOU WIN"
+LOSE → prints "GAME OVER"
+```
+
+**Player Mode sub-state (during PLAYER_TURN):**
+- `IDLE` — no unit selected
+- `STRIDE_MODE` — unit selected, showing move highlights
+- `ATTACK_MODE` — unit selected, showing attack target highlights
+
+---
+
+## Signals Emitted
+
+| Signal | When |
+|--------|------|
+| *(none emitted externally in 3D version)* | CM3D is the root; no parent to signal |
+
+> The 2D version emits `phase_changed(new_phase: String)` and `combat_ended(player_won: bool)`.
+
+---
+
+## Public Methods (called by other systems)
+
+None — CombatManager3D is the root; other systems signal *up* to it, not the other way around.
+
+---
+
+## Key Internal Methods
+
+| Method | Purpose |
+|--------|---------|
+| `_ready()` | Builds entire scene: env → camera → grid → units → UI |
+| `_make_unit_data(...)` | Factory for UnitData resources |
+| `_input(event)` | Entry point for all player clicks; dispatches by combat state |
+| `_handle_left_click()` | Raycasts grid cell, routes to select/move/attack |
+| `_initiate_attack(attacker, target)` | `await` chain: lunge anim → QTE → apply damage → shake |
+| `_on_qte_resolved(accuracy)` | Receives QTE result, calls `_calculate_damage()`, applies it |
+| `_run_enemy_turn()` | Iterates enemy units, simulates QTE via `qte_resolution` stat |
+| `_calculate_damage(atk, def, accuracy)` | `max(1, (atk - def) * accuracy)` |
+| `_check_win_lose()` | Checks for all-dead on either side, transitions to WIN/LOSE |
+| `_refresh_hud()` | Calls `hud.refresh()` — called after every meaningful state change |
+
+---
+
+## Damage Formula
+
+```
+damage = max(1, (attacker.attack - defender.defense) * accuracy)
+```
+
+- `accuracy` is 0.0–1.0 from QTE (or `qte_resolution` stat for enemies)
+- Floor of 1 ensures attacks always deal at least 1 damage
+
+---
+
+## Hardcoded Stats (placeholder — to be balanced post-playtest)
+
+| Unit | HP | Attack | Defense | Speed | QTE Res |
+|------|-----|--------|---------|-------|---------|
+| Player | 20 | 10 | 10 | 3 | — |
+| Grunt enemy | 15 | 8 | 6 | 2 | 0.3 |
+
+---
+
+## Notes
+
+- CM3D builds 3 player units (columns 1–2) and 3 enemy units (columns 3–4) on a 6×4 grid.
+- `_process_enemy_actions()` uses `await get_tree().create_timer(0.4)` between enemies for pacing.
+- The `await` on `_initiate_attack()` blocks the coroutine until QTE resolves — this is why `QTE_RUNNING` state exists to block input.

--- a/docs/map_directories/game_state.md
+++ b/docs/map_directories/game_state.md
@@ -1,0 +1,57 @@
+# System: Game State
+
+> Last updated: 2026-04-14 (Session 2 — Stage 1.5)
+
+---
+
+## Purpose
+
+`GameState` is the **autoload singleton** for run-wide persistent data. It is intended to be the single source of truth for anything that needs to survive across scenes — party roster, equipment, currency, map progress, faction reputation.
+
+**Current status: Stub.** The file exists as a scaffold but contains no live data or logic. No other system reads from or writes to it yet.
+
+---
+
+## Core File
+
+| File | Autoload Name | Role |
+|------|--------------|------|
+| `scripts/globals/GameState.gd` | `GameState` | Run-wide persistent data — stub |
+
+Registered as an autoload in `project.godot` so it is accessible from any script as `GameState`.
+
+---
+
+## Dependencies
+
+None currently. When fleshed out, it will be depended on by:
+- CombatManager (read party stats, write combat outcome)
+- Map system (read/write traversal progress)
+- Recruitment system (write new party members)
+
+---
+
+## Signals Emitted
+
+None currently.
+
+---
+
+## Planned Responsibilities (Stage 2+)
+
+| Data | Type | Notes |
+|------|------|-------|
+| Party roster | `Array[UnitData]` | Active + bench units for the run |
+| Run seed | `int` | For reproducibility |
+| Map progress | `Dictionary` | Node visited state |
+| Faction reputation | `Dictionary` | Per-faction standing |
+| Currency / resources | `int` | TBD |
+| Run flags | `Dictionary` | Misc boolean state |
+
+---
+
+## Notes
+
+- The singleton pattern was chosen so that any scene in the game can access run state without manual node references or signal chains up the tree.
+- Do not put **combat-local** state here (selected unit, current turn, etc.) — that belongs in CombatManager. GameState is for data that persists between combat encounters.
+- When Stage 2 begins (node map + recruitment), this file will need a full design pass.

--- a/docs/map_directories/grid_system.md
+++ b/docs/map_directories/grid_system.md
@@ -1,0 +1,133 @@
+# System: Grid System
+
+> Last updated: 2026-04-14 (Session 2 — Stage 1.5)
+
+---
+
+## Purpose
+
+The Grid is the **spatial authority** for combat. It owns:
+- The canonical map of which cells exist and which are occupied
+- All coordinate conversion math (world ↔ grid)
+- Per-cell color highlighting (move range, attack targets, default)
+- Mouse-to-cell input translation (3D: math raycast against Y=0 plane; 2D: pixel math)
+
+Two versions: `Grid3D.gd` (active, 3D) and `Grid.gd` (legacy 2D).
+
+---
+
+## Core Nodes / Scripts
+
+| File | Scene | Role |
+|------|-------|------|
+| `scripts/combat/Grid3D.gd` | `scenes/combat/Grid3D.tscn` | **Active** — 3D tile floor |
+| `scripts/combat/Grid.gd` | `scenes/combat/Grid.tscn` | Legacy 2D — `_draw()` + click input |
+
+`.tscn` files are minimal (root + script). All tile meshes are built in `_ready()`.
+
+---
+
+## Dependencies
+
+| System | How it's used |
+|--------|--------------|
+| **Unit3D / Unit** | Stored in `_occupied` dict; `get_unit_at()` returns the Unit object |
+| **CombatManager3D** | Calls all Grid methods — Grid itself has no direct dependency on CM |
+
+Grid has **no dependency** on Camera, HUD, QTE, or UnitData.
+
+---
+
+## Constants
+
+| Constant | 3D Value | 2D Value | Meaning |
+|----------|----------|----------|---------|
+| `COLS` | 6 | 6 | Grid width in cells |
+| `ROWS` | 4 | 4 | Grid height in cells |
+| `CELL_SIZE` | 2.0 | 80 | World units (3D) / pixels (2D) per cell |
+| `CELL_GAP` | 0.08 | — | Visual gap between tiles in 3D |
+
+---
+
+## Signals Emitted
+
+| Signal | When |
+|--------|------|
+| `cell_clicked(grid_pos: Vector2i)` | **2D only** — emitted from `_input()`. In 3D, CM3D calls `get_clicked_cell()` directly instead. |
+
+---
+
+## Public Methods
+
+### Coordinate Math
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `grid_to_world` | `(pos: Vector2i) -> Vector3` | Cell center in 3D world space |
+| `world_to_grid` | `(local_pos: Vector3) -> Vector2i` | World position → nearest cell (clamps to bounds) |
+| `get_clicked_cell` | `(camera: Camera3D, viewport: Viewport) -> Vector2i` | Raycasts from mouse through Y=0 plane; returns `(-1,-1)` on miss |
+
+### Occupancy
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `is_valid` | `(pos: Vector2i) -> bool` | Cell is within grid bounds |
+| `is_occupied` | `(pos: Vector2i) -> bool` | Cell has a unit registered |
+| `get_unit_at` | `(pos: Vector2i) -> Object` | Returns unit or `null` |
+| `set_occupied` | `(pos: Vector2i, unit: Object) -> void` | Registers a unit in the dict |
+| `clear_occupied` | `(pos: Vector2i) -> void` | Removes unit registration |
+
+### Movement
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `get_move_range` | `(origin: Vector2i, speed: int) -> Array[Vector2i]` | BFS flood-fill within Manhattan distance = speed; excludes occupied cells |
+
+### Highlighting
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `set_highlight` | `(pos: Vector2i, mode: String) -> void` | Modes: `"move"` (cyan), `"attack"` (red), `"select"` (yellow), `""` (clear one) |
+| `clear_highlights` | `() -> void` | Resets all highlighted cells to base color |
+
+---
+
+## Internal Data
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `_occupied` | `Dictionary` | `Vector2i → Object (Unit3D)` — occupancy map |
+| `_cell_materials` | `Array[StandardMaterial3D]` | One material per cell (COLS × ROWS), mutated for highlights |
+| `highlighted_cells` | `Dictionary` | `Vector2i → String (mode)` — tracks which cells are highlighted |
+
+---
+
+## Highlight Color Reference
+
+| Mode | Color |
+|------|-------|
+| Base (player side) | Dark blue-gray |
+| Base (enemy side) | Dark red-gray |
+| `"move"` | Cyan `#00cccc` |
+| `"attack"` | Red `#cc2200` |
+| `"select"` | Yellow `#cccc00` |
+
+Player side = col 0–2; enemy side = col 3–5 (visual distinction only, not enforced by Grid).
+
+---
+
+## 3D Raycast Logic (`get_clicked_cell`)
+
+No physics bodies used. The math:
+1. Build a ray from the camera through the mouse position.
+2. Intersect the ray with the Y=0 plane (the grid floor).
+3. Transform the hit point into the Grid's local space.
+4. Call `world_to_grid()` to snap to the nearest cell.
+5. Return `(-1, -1)` if the ray is parallel to the plane or the result is out of bounds.
+
+---
+
+## Notes
+
+- Grid does **not** own units. It only stores references in `_occupied`. Unit3D is the source of truth for unit state.
+- In 2D, `Grid.gd` also owns placement via `place_unit()` and `register_move()`. In 3D, CM3D manages this directly via `set_occupied()` / `clear_occupied()`.

--- a/docs/map_directories/hud_system.md
+++ b/docs/map_directories/hud_system.md
@@ -1,0 +1,82 @@
+# System: HUD System
+
+> Last updated: 2026-04-14 (Session 2 — Stage 1.5)
+
+---
+
+## Purpose
+
+The HUD displays **HP and energy status bars** for all 6 combatants (3 player, 3 enemy) as ASCII-style text bars. It sits in a CanvasLayer so it always renders over the 3D scene.
+
+The HUD is **duck-typed** — its `refresh()` method accepts any array of objects that have `.unit_name`, `.current_hp`, `.hp_max`, `.current_energy`, `.energy_max`, and `.is_alive` fields. This means it works with both `Unit` (2D) and `Unit3D` without any explicit type dependency.
+
+---
+
+## Core Nodes / Scripts
+
+| File | Scene | Role |
+|------|-------|------|
+| `scripts/ui/HUD.gd` | `scenes/ui/HUD.tscn` | ASCII HP/energy display |
+
+`.tscn` is minimal. All Label nodes are built in `_build_ui()`.
+
+---
+
+## Dependencies
+
+None. HUD has no runtime imports or node dependencies. It reads duck-typed unit objects passed in by CombatManager.
+
+---
+
+## Signals Emitted
+
+None.
+
+---
+
+## Public Methods
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `refresh` | `(player_units: Array, enemy_units: Array) -> void` | Rebuilds all display cards from current unit state. Call after any HP/energy change. |
+
+---
+
+## Display Format
+
+Each unit card is a `Label` node containing a multi-line string like:
+
+```
+[Warrior]
+HP  [████████░░] 16/20
+EN  [██████░░░░] 6/10
+```
+
+Dead units show `(dead)` in place of bars.
+
+---
+
+## ASCII Bar Formula (`_mini_bar`)
+
+```
+filled = round(current / maximum * width)
+bar = "█" × filled + "░" × (width - filled)
+```
+
+Default `width` = 10 characters.
+
+---
+
+## Layout
+
+- **Player cards:** anchored bottom-left, stacked vertically, 3 cards
+- **Enemy cards:** anchored bottom-right, stacked vertically, 3 cards
+- CanvasLayer layer = 5 (below QTEBar at layer 10)
+
+---
+
+## Notes
+
+- `refresh()` iterates up to 3 player units and 3 enemy units. If an array is shorter than 3 (unit died and was removed), the remaining cards show empty.
+- CombatManager3D calls `_refresh_hud()` which calls `hud.refresh(player_units, enemy_units)` — this is called after every meaningful state change (turn start, damage applied, unit death, combat end).
+- The duck-typing approach was a deliberate decision to avoid a separate HUD rewrite when upgrading from 2D to 3D units.

--- a/docs/map_directories/map.md
+++ b/docs/map_directories/map.md
@@ -1,0 +1,87 @@
+# RogueFinder — System Map
+
+> High-level index of all game systems. Read this first each session, then navigate to the relevant bucket file.
+> Last updated: 2026-04-14 (Session 2 — Stage 1.5 complete)
+
+---
+
+## System Index
+
+| System | Bucket File | Status | Layer |
+|--------|------------|--------|-------|
+| [Combat Manager](#combat-manager) | [combat_manager.md](combat_manager.md) | ✅ Active (3D) + Legacy (2D) | Core |
+| [Grid System](#grid-system) | [grid_system.md](grid_system.md) | ✅ Active (3D) + Legacy (2D) | Core |
+| [Unit System](#unit-system) | [unit_system.md](unit_system.md) | ✅ Active (3D) + Legacy (2D) | Core |
+| [QTE System](#qte-system) | [qte_system.md](qte_system.md) | ✅ Active | Core |
+| [Camera System](#camera-system) | [camera_system.md](camera_system.md) | ✅ Active (3D only) | Presentation |
+| [HUD System](#hud-system) | [hud_system.md](hud_system.md) | ✅ Active (duck-typed) | Presentation |
+| [Unit Data Resource](#unit-data-resource) | [unit_data.md](unit_data.md) | ✅ Active | Data |
+| [Game State](#game-state) | [game_state.md](game_state.md) | 🔲 Stub | Global |
+
+---
+
+## Dependency Graph
+
+```
+CombatManager3D
+  ├── Grid3D          (cell queries, highlights, world↔grid math)
+  ├── Unit3D ×6       (HP/energy state, movement, animations)
+  ├── QTEBar          (skill-check overlay → accuracy float)
+  ├── HUD             (display refresh after every state change)
+  ├── CameraController(built by CM3D; shake on hit)
+  └── UnitData        (stat resource passed into Unit3D.setup())
+
+Unit3D
+  └── UnitData        (stat source)
+
+GameState             (autoload stub — not yet wired to anything)
+```
+
+---
+
+## System Summaries
+
+### Combat Manager
+The central turn state machine. Owns all other scene nodes (builds them in `_ready()`). Routes player input, runs enemy AI, drives win/lose conditions. Lives in `CombatScene3D.tscn`.
+
+### Grid System
+Tracks which cells are occupied, calculates move ranges, manages per-cell color highlights. Handles world↔grid coordinate math and mouse→cell raycasting.
+
+### Unit System
+Stateful game object: HP, energy, turn flags (has_moved, has_acted). Renders as a colored box mesh in 3D. Emits `unit_died` and `unit_moved` signals. Plays lunge/flash animations.
+
+### QTE System
+Standalone sliding-bar skill check. Displayed as a CanvasLayer overlay. Emits `qte_resolved(accuracy: float)` when resolved. Used for both player attacks and enemy attacks (enemy uses `qte_resolution` stat to simulate auto-accuracy).
+
+### Camera System
+DOS2-style isometric orbit camera. Supports Q/E 45° rotation, scroll zoom, and procedural camera shake (`trigger_shake()`). Built and owned by CombatManager3D.
+
+### HUD System
+CanvasLayer that displays HP and energy as ASCII bars for all 6 units. Duck-typed `refresh()` accepts both `Unit` (2D) and `Unit3D` arrays — no explicit type dependency.
+
+### Unit Data Resource
+`@tool` Resource class. Holds all unit stats as `@export` fields. The only data contract between the Combat Manager (which constructs it) and Unit3D (which reads it via `setup()`).
+
+### Game State
+Autoload singleton stub. Intended for run-wide data (party roster, items, map progress). Not yet wired to any system.
+
+---
+
+## File Locations
+
+```
+res://
+├── scripts/
+│   ├── camera/CameraController.gd
+│   ├── combat/
+│   │   ├── CombatManager3D.gd   ← active
+│   │   ├── Unit3D.gd            ← active
+│   │   ├── Grid3D.gd            ← active
+│   │   ├── QTEBar.gd
+│   │   ├── CombatManager.gd     ← legacy 2D
+│   │   ├── Unit.gd              ← legacy 2D
+│   │   └── Grid.gd              ← legacy 2D
+│   ├── ui/HUD.gd
+│   └── globals/GameState.gd
+└── resources/UnitData.gd
+```

--- a/docs/map_directories/qte_system.md
+++ b/docs/map_directories/qte_system.md
@@ -1,0 +1,136 @@
+# System: QTE System
+
+> Last updated: 2026-04-14 (Session 2 — Stage 1.5)
+
+---
+
+## Purpose
+
+The QTE (Quick Time Event) system is a **standalone skill-check overlay**. It renders a sliding cursor bar over the game as a CanvasLayer and emits an accuracy float (0.0–1.0) when the player hits Space/click or the cursor expires.
+
+This accuracy value drives the damage formula in CombatManager. The system is completely self-contained — it neither knows nor cares what called it.
+
+Enemy "QTE" is simulated by CombatManager directly using the unit's `qte_resolution` stat — the QTEBar is not shown for enemy turns.
+
+---
+
+## Core Nodes / Scripts
+
+| File | Scene | Role |
+|------|-------|------|
+| `scripts/combat/QTEBar.gd` | `scenes/combat/QTEBar.tscn` | Sliding bar QTE, CanvasLayer layer 10 |
+
+`.tscn` is minimal. All UI nodes (bar background, sweet-spot panel, cursor, feedback label) are built in `_build_ui()`.
+
+---
+
+## Dependencies
+
+None. QTEBar has **no runtime dependencies** on other game systems. It is purely input-in → accuracy-out.
+
+---
+
+## Signals Emitted
+
+| Signal | Arguments | When |
+|--------|-----------|------|
+| `qte_resolved` | `accuracy: float` | Player presses action key, or cursor reaches the end without input |
+
+CombatManager subscribes to this signal before calling `start_qte()`.
+
+---
+
+## Public Methods
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `start_qte` | `() -> void` | Makes the bar visible and starts the cursor animation coroutine |
+
+All other methods are internal.
+
+---
+
+## Bar Layout
+
+```
+[===========================|=======|==========================]
+         dead zone        sweet spot        dead zone
+         (0.0–0.35)       (0.35–0.65)       (0.65–1.0)
+
+                            ↑ cursor slides left → right
+```
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `BAR_WIDTH` | 480.0 px | Total bar width |
+| `CURSOR_WIDTH` | 10.0 px | Visual cursor width |
+| `SWEET_SPOT_START` | 0.35 | Normalized start of sweet spot |
+| `SWEET_SPOT_END` | 0.65 | Normalized end of sweet spot |
+| `CURSOR_DURATION` | 1.8 s | Time for cursor to travel full bar |
+
+---
+
+## Accuracy Formula
+
+```
+pos = cursor normalized position (0.0 = left, 1.0 = right)
+center = 0.5
+
+if pos in [SWEET_SPOT_START, SWEET_SPOT_END]:
+    accuracy = 1.0 - abs(pos - center) * 2.0
+    # → 1.0 at dead center (0.5), 0.5 at sweet-spot edges
+else:
+    accuracy = 0.2   # missed sweet spot — glancing blow
+```
+
+**Result range:** 0.2 (miss) to 1.0 (perfect center hit).
+
+On cursor expiry (no input), `accuracy = 0.0` is passed — a complete miss.
+
+---
+
+## Input
+
+The QTE listens for:
+- `Space` keypress
+- Left mouse button click
+
+Input is only consumed when the bar is visible (`visible == true`). After registering a hit, input is blocked until the feedback animation completes and the bar hides itself.
+
+---
+
+## Flow
+
+```
+start_qte()
+  → show bar
+  → _animate_cursor() [coroutine]
+      → slides cursor from 0 → 1 over CURSOR_DURATION seconds
+      → if player hits input: _register_hit() → _finish_qte(accuracy)
+      → if cursor expires:    _on_cursor_expired() → _finish_qte(0.0)
+
+_finish_qte(accuracy)
+  → _show_feedback(accuracy)   # brief color flash + label
+  → await 0.45s
+  → hide bar
+  → emit qte_resolved(accuracy)
+```
+
+---
+
+## Feedback Display
+
+| Accuracy | Label text | Color |
+|----------|-----------|-------|
+| ≥ 0.8 | "PERFECT!" | Green |
+| ≥ 0.5 | "GOOD" | Yellow |
+| > 0.0 | "OK" | Orange |
+| 0.0 | "MISS" | Red |
+
+---
+
+## Notes
+
+- The bar is always present in the scene tree (built by CombatManager3D in `_setup_ui()`), hidden until `start_qte()` is called.
+- CombatManager enters `QTE_RUNNING` state before calling `start_qte()` to block all other input during the QTE.
+- The `qte_resolved` signal fires **after** the feedback animation, not immediately on input — this is intentional so the player sees their result before the attack resolves.

--- a/docs/map_directories/unit_data.md
+++ b/docs/map_directories/unit_data.md
@@ -1,0 +1,78 @@
+# System: Unit Data Resource
+
+> Last updated: 2026-04-14 (Session 2 — Stage 1.5)
+
+---
+
+## Purpose
+
+`UnitData` is a **pure data container** — a Godot `Resource` subclass with `@export` fields for every unit stat. It is the only formal data contract between the Combat Manager (which constructs stat records) and Unit3D (which reads them in `setup()`).
+
+Using a Resource (rather than a Dictionary or raw arguments) means stats can eventually be stored as `.tres` files and edited in the Godot inspector without code changes.
+
+---
+
+## Core File
+
+| File | Role |
+|------|------|
+| `resources/UnitData.gd` | Stat resource — `@export` fields only, no methods |
+
+---
+
+## Dependencies
+
+None. `UnitData` is a leaf node with no imports.
+
+---
+
+## Fields
+
+| Field | Type | Placeholder Value | Purpose |
+|-------|------|-------------------|---------|
+| `unit_name` | `String` | `""` | Display name (shown on Unit label) |
+| `is_player_unit` | `bool` | `false` | Determines team color (blue vs red) and AI behavior |
+| `hp_max` | `int` | `0` | Maximum hit points |
+| `speed` | `int` | `0` | Movement range in cells (Manhattan distance) |
+| `attack` | `int` | `0` | Attack stat — used in damage formula |
+| `defense` | `int` | `0` | Defense stat — used in damage formula |
+| `energy_max` | `int` | `0` | Maximum energy pool |
+| `energy_regen` | `int` | `0` | Energy restored at turn start |
+| `qte_resolution` | `float` | `0.0` | Enemy-only: simulated QTE accuracy (0.0–1.0) |
+
+---
+
+## Current Stat Presets (set in CombatManager3D._make_unit_data)
+
+| Unit Type | HP | Atk | Def | Spd | E.Max | E.Regen | QTE Res |
+|-----------|-----|-----|-----|-----|-------|---------|---------|
+| Player unit | 20 | 10 | 10 | 3 | 10 | 3 | — |
+| Grunt enemy | 15 | 8 | 6 | 2 | 10 | 3 | 0.3 |
+
+These are **placeholder values** — balance TBD after Stage 1.5 playtest.
+
+---
+
+## Usage Pattern
+
+```gdscript
+# CombatManager3D creates the data:
+var data: UnitData = _make_unit_data("Warrior", true, 20, 10, 10, 3, 0.0)
+
+# Unit3D reads it once in setup():
+func setup(unit_data: UnitData, pos: Vector2i) -> void:
+    unit_name = unit_data.unit_name
+    hp_max = unit_data.hp_max
+    current_hp = hp_max
+    # ... etc
+```
+
+After `setup()`, the Unit no longer references the UnitData object. All live state is copied into the Unit's own fields.
+
+---
+
+## Notes
+
+- `qte_resolution` is only meaningful for enemy units. Player units resolve QTE via the QTEBar input system.
+- The Resource pattern enables future `.tres` file authoring (e.g., unique enemy types defined in the editor without code changes).
+- No signals, no methods — this is intentional. UnitData is a plain data bag, not a behavior class.

--- a/docs/map_directories/unit_system.md
+++ b/docs/map_directories/unit_system.md
@@ -1,0 +1,132 @@
+# System: Unit System
+
+> Last updated: 2026-04-14 (Session 2 — Stage 1.5)
+
+---
+
+## Purpose
+
+A Unit is a **stateful game object** representing one combatant. It owns:
+- HP and energy values (current and max)
+- Turn flags (`has_moved`, `has_acted`)
+- Grid position
+- Its own visual representation (mesh, selection ring, label)
+- Attack lunge and hit flash animations
+
+Units do **not** know about the grid or other units. They receive instructions from CombatManager and report back via signals.
+
+Two versions: `Unit3D.gd` (active) and `Unit.gd` (legacy 2D).
+
+---
+
+## Core Nodes / Scripts
+
+| File | Scene | Role |
+|------|-------|------|
+| `scripts/combat/Unit3D.gd` | `scenes/combat/Unit3D.tscn` | **Active** — 3D box mesh unit |
+| `scripts/combat/Unit.gd` | `scenes/combat/Unit.tscn` | Legacy 2D — `ColorRect` + label |
+
+`.tscn` files are minimal. All child nodes (mesh, ring, label) are built in `_ready()` / `_build_visuals()`.
+
+---
+
+## Dependencies
+
+| System | How it's used |
+|--------|--------------|
+| **UnitData** | Read in `setup()` to initialize all stats |
+| **CameraController** | `get_sprite_dir()` takes camera forward vector (optional, for future 8-dir sprites) |
+
+Unit has **no dependency** on Grid, CombatManager, QTE, or HUD.
+
+---
+
+## Signals Emitted
+
+| Signal | Arguments | When |
+|--------|-----------|------|
+| `unit_died` | `unit: Unit3D` | HP drops to 0 in `take_damage()` |
+| `unit_moved` | `unit: Unit3D, new_pos: Vector2i` | After a successful `move_to()` |
+
+CombatManager subscribes to both signals on every unit.
+
+---
+
+## Public Methods
+
+### Lifecycle
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `setup` | `(unit_data: UnitData, pos: Vector2i) -> void` | Initializes all stats and positions unit in world space |
+
+### State Queries
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `can_stride` | `() -> bool` | Returns `not has_moved and is_alive` |
+| `can_act` | `(energy_cost: int = 3) -> bool` | Returns `not has_acted and current_energy >= energy_cost and is_alive` |
+
+### State Mutations
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `take_damage` | `(amount: int) -> void` | Subtracts HP; emits `unit_died` if HP ≤ 0; triggers hit flash |
+| `spend_energy` | `(amount: int) -> bool` | Deducts energy; returns `false` if insufficient |
+| `regen_energy` | `() -> void` | Adds `energy_regen` to `current_energy`, capped at `energy_max` |
+| `reset_turn` | `() -> void` | Clears `has_moved` and `has_acted`; calls `regen_energy()` |
+| `move_to` | `(new_pos: Vector2i) -> void` | Updates `grid_pos`, moves Node3D to world position, emits `unit_moved` |
+
+### Visual
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `set_selected` | `(selected: bool) -> void` | Shows/hides the CylinderMesh selection ring |
+| `play_attack_anim` | `(target_world: Vector3) -> void` | `await` coroutine: lunge toward target and snap back |
+| `get_sprite_dir` | `(camera_forward: Vector3) -> int` | Returns 0–7 for 8-directional sprite selection (future use) |
+
+---
+
+## Internal State
+
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `current_hp` | `int` | `data.hp_max` | Current hit points |
+| `current_energy` | `int` | `data.energy_max` | Current action energy |
+| `grid_pos` | `Vector2i` | from `setup()` | Current cell on the grid |
+| `has_moved` | `bool` | `false` | Stride used this turn |
+| `has_acted` | `bool` | `false` | Active action used this turn |
+| `is_alive` | `bool` | `true` | False after HP reaches 0 |
+| `is_player_unit` | `bool` | from `UnitData` | Determines base color (blue vs red) |
+
+---
+
+## Visual Details (3D)
+
+| Node | Type | Purpose |
+|------|------|---------|
+| Box mesh | `MeshInstance3D` | Main body — blue for player, red for enemy |
+| Selection ring | `MeshInstance3D` (CylinderMesh) | Yellow ring shown when `set_selected(true)` |
+| Label | `Label3D` | Billboard showing unit name, HP, energy |
+
+**Box dimensions:** `0.7 × 1.6 × 0.7` world units; base sits at Y=0 (half-height offset applied).
+
+### Hit Flash
+`_play_hit_flash()` is a coroutine triggered inside `take_damage()`. It:
+1. Sets box material to white (`#ffffff`)
+2. Awaits `create_timer(0.15)`
+3. Restores the original base color
+
+### Attack Lunge
+`play_attack_anim(target_world)` is a coroutine called by CombatManager before QTE resolves. It:
+1. Calculates direction toward target
+2. Tweens position 0.6 units toward target over 0.12s
+3. Tweens back to origin over 0.10s
+
+---
+
+## Notes
+
+- `move_to()` does not validate against Grid — that's CombatManager's job before calling it.
+- `take_damage()` calls `_play_hit_flash()` as a fire-and-forget coroutine (no `await`), so damage application is not blocked by the animation.
+- `unit_died` fires synchronously inside `take_damage()`, before the flash completes.


### PR DESCRIPTION
Adds /docs/map_directories/ with a system map index and 8 bucket files covering Combat Manager, Grid, Unit, QTE, Camera, HUD, UnitData, and GameState. Updates CLAUDE.md with Map Protocol and auto-update rules. Also initializes docs/backlog.md.